### PR TITLE
Use UrlEncode per value not on the entire query string

### DIFF
--- a/Rally.RestApi/Request.cs
+++ b/Rally.RestApi/Request.cs
@@ -193,17 +193,17 @@ namespace Rally.RestApi
                     continue;
                 if (tmpParameters[key] is bool)
                 {
-                    list.Add(key + "=" + tmpParameters[key].ToString().ToLower());
+                    list.Add(key + "=" + HttpUtility.UrlEncode(tmpParameters[key].ToString().ToLower()));
                 }
                 else
                 {
                     string value = tmpParameters[key].ToString();
-                    list.Add(key + "=" + value);
+                    list.Add(key + "=" + HttpUtility.UrlEncode(value));
                 }
             }
 
-            list.Add("fetch=" + string.Join(",", fetch));
-            return Endpoint + extension + "?" + HttpUtility.UrlEncode(string.Join("&", list.ToArray()));
+            list.Add("fetch=" + HttpUtility.UrlEncode(string.Join(",", fetch)));
+            return Endpoint + extension + "?" + string.Join("&", list.ToArray());
         }
 
         internal string Endpoint


### PR DESCRIPTION
UrlEncoding needs to be at each value level versus UrlEncoding the entire string. The difference is between this:
`https://rally1.rallydev.com/slm/webservice/v2.0/defect?pagesize%3d200%26order%3dObjectID%26start%3d1%26fetch%3dtrue`
and this:
`https://rally1.rallydev.com/slm/webservice/v2.0/defect.js?pagesize=200&order=ObjectID&start=1&fetch=true`

The first one is what is currently being used and it doesn't work at all -- I'm not sure how any of your current unit tests are passing. Simple example would be to try and do a query or `restApi.GetAttributesByType("defect")`
