### PR TITLE
Adding comments to methods.

### DIFF
--- a/Rally.RestApi.Test/Rally.RestApi.Test.csproj
+++ b/Rally.RestApi.Test/Rally.RestApi.Test.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Rally.RestApi.Test/RallyRestApiTest.cs
+++ b/Rally.RestApi.Test/RallyRestApiTest.cs
@@ -37,11 +37,11 @@ namespace Rally.RestApi.Test
 			}
 
 			var connInfo = new ConnectionInfo();
-			connInfo.authType = AuthorizationType.Basic;
-			connInfo.username = userName;
-			connInfo.password = password;
-			connInfo.server = new Uri(server);
-			connInfo.wsapiVersion = wsapiVersion;
+			connInfo.AuthType = AuthorizationType.Basic;
+			connInfo.UserName = userName;
+			connInfo.Password = password;
+			connInfo.Server = new Uri(server);
+			connInfo.WsapiVersion = wsapiVersion;
 
 			return new RallyRestApi(connInfo);
 		}

--- a/Rally.RestApi.Test/SSOHelperTest.cs
+++ b/Rally.RestApi.Test/SSOHelperTest.cs
@@ -8,33 +8,33 @@ using System.Net;
 
 namespace Rally.RestApi.Test
 {
-    [TestClass]
-    public class SSOHelperTest
-    {
-        [ClassInitialize()]
-        public static void Initialize(TestContext testContext)
-        {
-        }
+	[TestClass]
+	public class SSOHelperTest
+	{
+		[ClassInitialize()]
+		public static void Initialize(TestContext testContext)
+		{
+		}
 
 
-        [TestMethod]
-        [DeploymentItem("Rally.RestApi.Test\\data\\")]
-        public void ParseSSOTokenPage()
-        {
-            Cookie cookie = SSOHelper.parsSSOLandingPage(getDataFromFile("SSOTokenPage.html"));
-            Assert.IsNotNull(cookie);
-            Assert.AreEqual(cookie.Name, "ZSESSIONID");
-            Assert.AreEqual(cookie.Value, "khkjhkhkhkhkjhh");
-            Assert.AreEqual(cookie.Domain, "us1.rallydev.com");
-            Assert.AreEqual(cookie.Path, "/");
-        }
+		[TestMethod]
+		[DeploymentItem("Rally.RestApi.Test\\data\\")]
+		public void ParseSSOTokenPage()
+		{
+			Cookie cookie = SSOHelper.ParseSSOLandingPage(getDataFromFile("SSOTokenPage.html"));
+			Assert.IsNotNull(cookie);
+			Assert.AreEqual(cookie.Name, "ZSESSIONID");
+			Assert.AreEqual(cookie.Value, "khkjhkhkhkhkjhh");
+			Assert.AreEqual(cookie.Domain, "us1.rallydev.com");
+			Assert.AreEqual(cookie.Path, "/");
+		}
 
-        private String getDataFromFile(String filename)
-        {
-            using (StreamReader sr = new StreamReader(filename))
-            {
-                return sr.ReadToEnd();
-            }
-        }
-    }
+		private String getDataFromFile(String filename)
+		{
+			using (StreamReader sr = new StreamReader(filename))
+			{
+				return sr.ReadToEnd();
+			}
+		}
+	}
 }

--- a/Rally.RestApi/AuthorizationType.cs
+++ b/Rally.RestApi/AuthorizationType.cs
@@ -5,9 +5,18 @@ using System.Text;
 
 namespace Rally.RestApi
 {
-    public enum AuthorizationType
-    {
-        Basic,
-        SSO
-    }
+	/// <summary>
+	/// The types of authorization that are available.
+	/// </summary>
+	public enum AuthorizationType
+	{
+		/// <summary>
+		/// Basic authorization where the user provides a username and password.
+		/// </summary>
+		Basic,
+		/// <summary>
+		/// SSO authorization.
+		/// </summary>
+		SSO
+	}
 }

--- a/Rally.RestApi/ConnectionInfo.cs
+++ b/Rally.RestApi/ConnectionInfo.cs
@@ -7,30 +7,66 @@ using Rally.RestApi;
 
 namespace Rally.RestApi
 {
-    public class ConnectionInfo : IConnectionInfo
-    {
-        public ConnectionInfo()
-        {
-            port = 0;
-        }
+	/// <summary>
+	/// An object for tracking connection information.
+	/// </summary>
+	public class ConnectionInfo : IConnectionInfo
+	{
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		public ConnectionInfo()
+		{
+			Port = 0;
+		}
 
-        public virtual AuthorizationType authType {get;set;}
-        public virtual Uri server { get; set; }
-        public virtual String username { get; set; }
-        public virtual String password { get; set; }
-        public virtual WebProxy proxy { get; set; }
-        public virtual String wsapiVersion { get; set; }
-        public virtual Cookie authCookie { get; set; }
-        public virtual int port { get; set; }
+		/// <summary>
+		/// The authorization type for this connection.
+		/// </summary>
+		public virtual AuthorizationType AuthType { get; set; }
+		/// <summary>
+		/// The server this connection is to.
+		/// </summary>
+		public virtual Uri Server { get; set; }
+		/// <summary>
+		/// The username for this connection.
+		/// </summary>
+		public virtual String UserName { get; set; }
+		/// <summary>
+		/// The password for this connection.
+		/// </summary>
+		public virtual String Password { get; set; }
+		/// <summary>
+		/// The proxy server to use for this connection.
+		/// </summary>
+		public virtual WebProxy Proxy { get; set; }
+		/// <summary>
+		/// The WSAPI version we are talking to.
+		/// </summary>
+		public virtual String WsapiVersion { get; set; }
+		/// <summary>
+		/// The authorization cookie for this connection.
+		/// </summary>
+		public virtual Cookie AuthCookie { get; set; }
+		/// <summary>
+		/// The port we are connecting to.
+		/// </summary>
+		public virtual int Port { get; set; }
 
-        public virtual void doSSOAuth()
-        {
-            throw new NotImplementedException();
-        }
+		/// <summary>
+		/// Perform SSO authorization for this connection.
+		/// </summary>
+		public virtual void DoSSOAuth()
+		{
+			throw new NotImplementedException();
+		}
 
-        protected Cookie parseSSOLandingPage(String ssoLandingPage)
-        {
-            return SSOHelper.parsSSOLandingPage(ssoLandingPage);
-        }
-    }
+		/// <summary>
+		/// Parses an SSO landing page to retreive the Cookie that is embedded for SSO.
+		/// </summary>
+		protected Cookie ParseSSOLandingPage(String ssoLandingPage)
+		{
+			return SSOHelper.ParseSSOLandingPage(ssoLandingPage);
+		}
+	}
 }

--- a/Rally.RestApi/DynamicJsonSerializer.cs
+++ b/Rally.RestApi/DynamicJsonSerializer.cs
@@ -6,16 +6,25 @@ using System.Web.Script.Serialization;
 
 namespace Rally.RestApi
 {
+	/// <summary>
+	/// A class for serializing/deserizalizing dynamic JSON objects.
+	/// </summary>
 	public class DynamicJsonSerializer
 	{
 		readonly JavaScriptSerializer deSerializer;
+		/// <summary>
+		/// Constructor
+		/// </summary>
 		public DynamicJsonSerializer()
 		{
 			deSerializer = new JavaScriptSerializer();
 			deSerializer.MaxJsonLength = int.MaxValue;
 			deSerializer.RegisterConverters(new JavaScriptConverter[] { new DynamicJsonConverter() });
 		}
-		// as dynamic
+
+		/// <summary>
+		/// Deserializes a JSON data string into a dynamic JSON Object.
+		/// </summary>
 		public DynamicJsonObject Deserialize(string json)
 		{
 			try
@@ -30,10 +39,18 @@ namespace Rally.RestApi
 					throw;
 			}
 		}
+
+		/// <summary>
+		/// Serializes a dynamic JSON Object into a string.
+		/// </summary>
 		public string Serialize(DynamicJsonObject value)
 		{
 			return SerializeDictionary(value.Dictionary);
 		}
+
+		/// <summary>
+		/// Serializes a dictionary into a string.
+		/// </summary>
 		public string SerializeDictionary(IDictionary<string, object> dictionary)
 		{
 			var builder = new StringBuilder();
@@ -88,7 +105,7 @@ namespace Rally.RestApi
 			{
 				return "null";
 			}
-			
+
 			if (obj is string)
 			{
 				return "\"" + ((String)obj).Replace(@"\", @"\\").Replace("\"", "\\\"") + "\"";

--- a/Rally.RestApi/HttpService.cs
+++ b/Rally.RestApi/HttpService.cs
@@ -26,14 +26,14 @@ namespace Rally.RestApi
 		{
 			this.connectionInfo = connectionInfo;
 
-			if (connectionInfo.authCookie != null)
+			if (connectionInfo.AuthCookie != null)
 			{
 				setAuthCookie();
 			}
-			else if (connectionInfo.authType == AuthorizationType.Basic)
+			else if (connectionInfo.AuthType == AuthorizationType.Basic)
 			{
-				Server = connectionInfo.server;
-				credentials = new CredentialCache { { connectionInfo.server, "Basic", new NetworkCredential(connectionInfo.username, connectionInfo.password) } };
+				Server = connectionInfo.Server;
+				credentials = new CredentialCache { { connectionInfo.Server, "Basic", new NetworkCredential(connectionInfo.UserName, connectionInfo.Password) } };
 			}
 			else
 			{
@@ -43,18 +43,18 @@ namespace Rally.RestApi
 
 		private void doSSOAuth()
 		{
-			connectionInfo.doSSOAuth();
+			connectionInfo.DoSSOAuth();
 			setAuthCookie();
 		}
 
 		void setAuthCookie()
 		{
-			var uriBuilder = new UriBuilder(connectionInfo.authCookie.Secure ? "https" : "http", connectionInfo.authCookie.Domain);
-			if (connectionInfo.port > 0)
-				uriBuilder.Port = connectionInfo.port;
+			var uriBuilder = new UriBuilder(connectionInfo.AuthCookie.Secure ? "https" : "http", connectionInfo.AuthCookie.Domain);
+			if (connectionInfo.Port > 0)
+				uriBuilder.Port = connectionInfo.Port;
 
 			Server = uriBuilder.Uri;
-			cookies.Add(connectionInfo.authCookie);
+			cookies.Add(connectionInfo.AuthCookie);
 		}
 
 		WebClient GetWebClient(IEnumerable<KeyValuePair<string, string>> headers = null, bool isCacheable = false)
@@ -75,8 +75,8 @@ namespace Rally.RestApi
 					webClient.Headers.Add(pairs.Key, pairs.Value);
 			if (credentials != null)
 				webClient.Credentials = credentials;
-			if (connectionInfo.proxy != null)
-				webClient.Proxy = connectionInfo.proxy;
+			if (connectionInfo.Proxy != null)
+				webClient.Proxy = connectionInfo.Proxy;
 			return webClient;
 		}
 
@@ -107,7 +107,7 @@ namespace Rally.RestApi
 				catch (WebException e)
 				{
 					if (((HttpWebResponse)e.Response).StatusCode == HttpStatusCode.Unauthorized &&
-							connectionInfo.authType != AuthorizationType.Basic)
+							connectionInfo.AuthType != AuthorizationType.Basic)
 					{
 						if (retries > MAX_RETRIES)
 						{
@@ -164,7 +164,7 @@ namespace Rally.RestApi
 				{
 					if (e.Response != null &&
 							((HttpWebResponse)e.Response).StatusCode == HttpStatusCode.Unauthorized &&
-							connectionInfo.authType != AuthorizationType.Basic)
+							connectionInfo.AuthType != AuthorizationType.Basic)
 					{
 						if (retries > MAX_RETRIES)
 						{

--- a/Rally.RestApi/IConnectionInfo.cs
+++ b/Rally.RestApi/IConnectionInfo.cs
@@ -6,17 +6,46 @@ using System.Net;
 
 namespace Rally.RestApi
 {
-    public interface IConnectionInfo
-    {
-        AuthorizationType authType { get; }
-        Uri server { get; }
-        String username { get; }
-        String password { get; }
-        WebProxy proxy { get; }
-        String wsapiVersion { get; }
-        Cookie authCookie { get; set; }
-        int port { get; set; }
-
-        void doSSOAuth();
-    }
+	/// <summary>
+	/// An interface for connection information.
+	/// </summary>
+	public interface IConnectionInfo
+	{
+		/// <summary>
+		/// The authorization type for this connection.
+		/// </summary>
+		AuthorizationType AuthType { get; }
+		/// <summary>
+		/// The server this connection is to.
+		/// </summary>
+		Uri Server { get; }
+		/// <summary>
+		/// The username for this connection.
+		/// </summary>
+		String UserName { get; }
+		/// <summary>
+		/// The password for this connection.
+		/// </summary>
+		String Password { get; }
+		/// <summary>
+		/// The proxy server to use for this connection.
+		/// </summary>
+		WebProxy Proxy { get; }
+		/// <summary>
+		/// The WSAPI version we are talking to.
+		/// </summary>
+		String WsapiVersion { get; }
+		/// <summary>
+		/// The authorization cookie for this connection.
+		/// </summary>
+		Cookie AuthCookie { get; set; }
+		/// <summary>
+		/// The port we are connecting to.
+		/// </summary>
+		int Port { get; set; }
+		/// <summary>
+		/// Perform SSO authorization for this connection.
+		/// </summary>
+		void DoSSOAuth();
+	}
 }

--- a/Rally.RestApi/Rally.RestApi.csproj
+++ b/Rally.RestApi/Rally.RestApi.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Rally.RestApi.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Rally.RestApi/RallyRestApi.cs
+++ b/Rally.RestApi/RallyRestApi.cs
@@ -124,6 +124,15 @@ namespace Rally.RestApi
 
 		#endregion
 
+		/// <summary>
+		/// Construct a new RallyRestApi with the specified
+		/// username, password, server and WSAPI version
+		/// </summary>
+		/// <param name="username">The username to be used for access</param>
+		/// <param name="password">The password to be used for access</param>
+		/// <param name="rallyServer">The Rally server to use (defaults to DEFAULT_SERVER)</param>
+		/// <param name="webServiceVersion">The WSAPI version to use (defaults to DEFAULT_WSAPI_VERSION)</param>
+		/// <param name="proxy">Optional proxy configuration</param>
 		public RallyRestApi(
 				string username,
 				string password,
@@ -153,12 +162,12 @@ namespace Rally.RestApi
 		)
 			: this(new ConnectionInfo()
 			{
-				authType = AuthorizationType.Basic,
-				username = username,
-				password = password,
-				server = serverUrl,
-				wsapiVersion = webServiceVersion,
-				proxy = proxy
+				AuthType = AuthorizationType.Basic,
+				UserName = username,
+				Password = password,
+				Server = serverUrl,
+				WsapiVersion = webServiceVersion,
+				Proxy = proxy
 			})
 		{
 		}
@@ -170,7 +179,7 @@ namespace Rally.RestApi
 		public RallyRestApi(IConnectionInfo connectionInfo)
 		{
 			Service = new HttpService(connectionInfo);
-			wsapiVersion = connectionInfo.wsapiVersion ?? DEFAULT_WSAPI_VERSION;
+			wsapiVersion = connectionInfo.WsapiVersion ?? DEFAULT_WSAPI_VERSION;
 		}
 
 		/// <summary>
@@ -250,7 +259,10 @@ namespace Rally.RestApi
 			return serializer.Deserialize(Service.Get(uri, GetProcessedHeaders()));
 		}
 
-		public DynamicJsonObject post(String relativeUri, DynamicJsonObject data)
+		/// <summary>
+		/// Performs a post of data to the provided URI.
+		/// </summary>
+		public DynamicJsonObject Post(String relativeUri, DynamicJsonObject data)
 		{
 			Uri uri = new Uri(String.Format("{0}slm/webservice/{1}/{2}", Service.Server.AbsoluteUri, wsapiVersion, relativeUri));
 			string postData = serializer.Serialize(data);
@@ -449,34 +461,34 @@ namespace Rally.RestApi
 			return string.Equals(wrappedReponse.Fields.FirstOrDefault(), "OperationResult", StringComparison.CurrentCultureIgnoreCase) ? null : wrappedReponse[wrappedReponse.Fields.First()];
 		}
 
-        /// <summary>
-        /// Get the object described by the specified reference scoped to the provided workspace.
-        /// </summary>
-        /// <param name="aRef">the reference</param>
-        /// <param name="workspaceRef">workspace scope</param>
-        /// <param name="fetchedFields">the list of object fields to be fetched</param>
-        /// <returns>The requested object</returns>
-        public dynamic GetByReferenceAndWorkspace(string aRef, string workspaceRef, params string[] fetchedFields)
-        {
-            if (fetchedFields.Length == 0)
-            {
-                fetchedFields = new string[] { "true" };
-            }
+		/// <summary>
+		/// Get the object described by the specified reference scoped to the provided workspace.
+		/// </summary>
+		/// <param name="aRef">the reference</param>
+		/// <param name="workspaceRef">workspace scope</param>
+		/// <param name="fetchedFields">the list of object fields to be fetched</param>
+		/// <returns>The requested object</returns>
+		public dynamic GetByReferenceAndWorkspace(string aRef, string workspaceRef, params string[] fetchedFields)
+		{
+			if (fetchedFields.Length == 0)
+			{
+				fetchedFields = new string[] { "true" };
+			}
 
-            if (!aRef.Contains(".js"))
-            {
-                aRef = aRef + ".js";
-            }
+			if (!aRef.Contains(".js"))
+			{
+				aRef = aRef + ".js";
+			}
 
-            string workspaceClause = "";
-            if (workspaceRef != null)
-                workspaceClause = "workspace="+workspaceRef+"&";
+			string workspaceClause = "";
+			if (workspaceRef != null)
+				workspaceClause = "workspace=" + workspaceRef + "&";
 
-            DynamicJsonObject wrappedReponse = DoGet(GetFullyQualifiedUri(aRef + "?" + workspaceClause + "fetch=" + string.Join(",", fetchedFields)));
-            return string.Equals(wrappedReponse.Fields.FirstOrDefault(), "OperationResult", StringComparison.CurrentCultureIgnoreCase) ? null : wrappedReponse[wrappedReponse.Fields.First()];
-        }
+			DynamicJsonObject wrappedReponse = DoGet(GetFullyQualifiedUri(aRef + "?" + workspaceClause + "fetch=" + string.Join(",", fetchedFields)));
+			return string.Equals(wrappedReponse.Fields.FirstOrDefault(), "OperationResult", StringComparison.CurrentCultureIgnoreCase) ? null : wrappedReponse[wrappedReponse.Fields.First()];
+		}
 
-        /// <summary>
+		/// <summary>
 		/// Delete the object described by the specified type and object id.
 		/// </summary>
 		/// <param name="workspaceRef">the workspace from which the object will be deleted.  Null means that the server will pick a workspace.</param>

--- a/Rally.RestApi/SSOHelper.cs
+++ b/Rally.RestApi/SSOHelper.cs
@@ -13,53 +13,59 @@ using System.Reflection;
 
 namespace Rally.RestApi
 {
-    class SSOHelper
-    {
-        public static Cookie parsSSOLandingPage(String htmlPage)
-        {
-            Cookie authCookie = null;
-            HtmlDocument doc = new HtmlDocument();
-            doc.LoadHtml(htmlPage);
-            HtmlNodeCollection inputs = doc.DocumentNode.SelectNodes("//input");
-            if (inputs != null && inputs.Count > 0)
-            {
-                authCookie = new Cookie();
+	/// <summary>
+	/// A helper class for working with SSO.
+	/// </summary>
+	class SSOHelper
+	{
+		/// <summary>
+		/// Parses an SSO landing page to retreive the Cookie that is embedded for SSO.
+		/// </summary>
+		public static Cookie ParseSSOLandingPage(String htmlPage)
+		{
+			Cookie authCookie = null;
+			HtmlDocument doc = new HtmlDocument();
+			doc.LoadHtml(htmlPage);
+			HtmlNodeCollection inputs = doc.DocumentNode.SelectNodes("//input");
+			if (inputs != null && inputs.Count > 0)
+			{
+				authCookie = new Cookie();
 
-                foreach (HtmlNode inputNode in inputs)
-                {
-                    switch (inputNode.GetAttributeValue("name", ""))
-                    {
-                        case "authCookieName":
-                            authCookie.Name = inputNode.GetAttributeValue("value", "");
-                            continue;
-                        case "authCookieValue":
-                            authCookie.Value = inputNode.GetAttributeValue("value", "");
-                            continue;
-                        case "authCookieDomain":
-                            String domain = inputNode.GetAttributeValue("value", "");
-                            authCookie.Domain = domain == null || domain == "null" ?  "" : domain;
-                            continue;
-                        case "authCookiePath":
-                            String path = inputNode.GetAttributeValue("value", "");
-                            authCookie.Path = path == null || path == "null" ? "" : path;
-                            continue;
-                    }
-                }
+				foreach (HtmlNode inputNode in inputs)
+				{
+					switch (inputNode.GetAttributeValue("name", ""))
+					{
+						case "authCookieName":
+							authCookie.Name = inputNode.GetAttributeValue("value", "");
+							continue;
+						case "authCookieValue":
+							authCookie.Value = inputNode.GetAttributeValue("value", "");
+							continue;
+						case "authCookieDomain":
+							String domain = inputNode.GetAttributeValue("value", "");
+							authCookie.Domain = domain == null || domain == "null" ? "" : domain;
+							continue;
+						case "authCookiePath":
+							String path = inputNode.GetAttributeValue("value", "");
+							authCookie.Path = path == null || path == "null" ? "" : path;
+							continue;
+					}
+				}
 
-                if (String.IsNullOrWhiteSpace(authCookie.Name) ||
-                    String.IsNullOrWhiteSpace(authCookie.Value))
-                {
-                    authCookie = null;
-                }
-            }
+				if (String.IsNullOrWhiteSpace(authCookie.Name) ||
+						String.IsNullOrWhiteSpace(authCookie.Value))
+				{
+					authCookie = null;
+				}
+			}
 
-            if (authCookie == null)
-            {
-                Trace.TraceWarning("Unable to parse SSO landing page.\n{0}",htmlPage);
-                throw new Exception("Unable to parse SSO landing page");
-            }
-            Trace.TraceInformation("Sucessfully parsed SSO token page.\n{0}",htmlPage);
-            return authCookie;
-        }
-    }
+			if (authCookie == null)
+			{
+				Trace.TraceWarning("Unable to parse SSO landing page.\n{0}", htmlPage);
+				throw new Exception("Unable to parse SSO landing page");
+			}
+			Trace.TraceInformation("Sucessfully parsed SSO token page.\n{0}", htmlPage);
+			return authCookie;
+		}
+	}
 }


### PR DESCRIPTION
Adding setting for Rally.RestApi.Test.csproj to treat warnings as errors to prevent externally accessible methods from being added without a comment header.
Fixed naming convention of some methods and properties from camelCase to PascalCase.
