### PR TITLE
Request.AddParameter()

### DIFF
--- a/Rally.RestApi.Test/RequestTest.cs
+++ b/Rally.RestApi.Test/RequestTest.cs
@@ -129,5 +129,24 @@ namespace Rally.RestApi.Test
 			else
 				Assert.AreEqual(finalUrlToCheck, request.Endpoint);
 		}
+
+
+	    [TestMethod]
+	    public void TestAddParameter()
+	    {
+	        var request = new Request();
+	        var count = request.Parameters.Count;
+	        var result = request.AddParameter("something", "somethingValue");
+	        Assert.IsTrue(result);
+	        Assert.AreEqual(count + 1, request.Parameters.Count);
+            Assert.IsTrue(request.Parameters.ContainsKey("something"));
+            Assert.AreEqual("somethingValue", request.Parameters["something"]);
+
+            //doesn't overwrite
+            result = request.AddParameter("something", "somethingElse");
+            Assert.IsFalse(result);
+            Assert.AreNotEqual("somethingElse", request.Parameters["something"]);
+            Assert.AreEqual("somethingValue", request.Parameters["something"]);
+	    }
 	}
 }

--- a/Rally.RestApi/Request.cs
+++ b/Rally.RestApi/Request.cs
@@ -199,6 +199,22 @@ namespace Rally.RestApi
 
 		#endregion
 
+        #region AddParameter
+	    /// <summary>
+	    /// Ability to add parameters other than the ones explicitly exposed.
+	    /// </summary>
+	    /// <param name="key"></param>
+	    /// <param name="value"></param>
+	    /// <returns>true if added. false if the key already existed</returns>
+	    public bool AddParameter(string key, string value)
+	    {
+	        if (GetParameterValue(key, null) != null)
+	            return false;
+	        Parameters[key] = value;
+	        return true;
+	    }
+	    #endregion
+
 		#region Helper: GetParameterValue
 		private dynamic GetParameterValue(string keyValue, object defaultValue = null)
 		{


### PR DESCRIPTION
Allows passing types based on this stackoverflow question:
http://stackoverflow.com/questions/29373833/cant-query-order-on-built-in-rally-fields-could-not-read-all-instances-of-clas
