### PR TITLE
Always return true from DynamicJsonObject.TryGetMember

### DIFF
--- a/Rally.RestApi.Test/DynamicJsonObjectTest.cs
+++ b/Rally.RestApi.Test/DynamicJsonObjectTest.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Rally.RestApi.Json;
+
+namespace Rally.RestApi.Test
+{
+    [TestClass]
+    public class DynamicJsonObjectTest
+    {
+        [TestMethod]
+        public void DynamicJsonObject_ExistingField_Valid()
+        {
+            dynamic djo = new DynamicJsonObject();
+            djo.someValue = "something";
+            Assert.AreEqual("something", djo.someValue);
+        }
+
+        /// <summary>
+        /// Null value in defined field on DynamicJsonObject should not throw exception
+        /// </summary>
+        [TestMethod]
+        public void DynamicJsonObject_ExistingField_ShouldBeNull()
+        {
+            dynamic djo = new DynamicJsonObject();
+            djo.nullValue = null;
+            Assert.IsNull(djo.nullValue);
+        }
+
+        /// <summary>
+        ///  Accessing non-existent field on DynamicJsonObject should NOT fail, and should return null
+        /// </summary>
+        [TestMethod]
+        public void DynamicJsonObject_NonExistentValue_ShouldBeNull()
+        {
+            dynamic djo = new DynamicJsonObject();
+            var thisCodeShouldNotThrowException = djo.nonexistent;
+            Assert.IsNull(thisCodeShouldNotThrowException);
+        }
+    }
+}

--- a/Rally.RestApi.Test/Rally.RestApi.Test.csproj
+++ b/Rally.RestApi.Test/Rally.RestApi.Test.csproj
@@ -60,6 +60,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CachedRequestTest.cs" />
+    <Compile Include="DynamicJsonObjectTest.cs" />
     <Compile Include="Example.cs" />
     <Compile Include="OperationResultTest.cs" />
     <Compile Include="Properties\Settings.Designer.cs">

--- a/Rally.RestApi/Json/DynamicJsonObject.cs
+++ b/Rally.RestApi/Json/DynamicJsonObject.cs
@@ -39,14 +39,14 @@ namespace Rally.RestApi.Json
 		/// </summary>
 		/// <param name="binder">The member to get</param>
 		/// <param name="result">The value</param>
-		/// <returns>true if successful, false otherwise</returns>
+		/// <returns>true. even if member contains a null value or if the member does not exist. </returns>
 		public override bool TryGetMember(GetMemberBinder binder, out object result)
 		{
-			result = GetMember(binder.Name);
-			return (result != null) ? true : false;
+		    result = GetMember(binder.Name);
+            return true;  // Prevent exceptions
 		}
 
-		/// <summary>
+	    /// <summary>
 		/// Get the value of the specified member
 		/// Equivalent to using [name].
 		/// </summary>


### PR DESCRIPTION
-Prevents exceptions (returning false from TryGetMember throws an exception)
-Returns null if the member has not been defined.
-Returns null if the member actually contains null.
-Includes unit tests
