### PR TITLE
Add a ToDictionary function to the DynamicJsonObject

### DIFF
--- a/Rally.RestApi.Test/DynamicJsonObjectTest.cs
+++ b/Rally.RestApi.Test/DynamicJsonObjectTest.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Rally.RestApi.Json;
+
+namespace Rally.RestApi.Test
+{
+    [TestClass]
+    public class DynamicJsonObjectTest
+    {
+        /// <summary>
+        ///A test for ToDictionary
+        ///</summary>
+        [TestMethod]
+        public void DynamicJsonObject_ToDictionary()
+        {
+            dynamic djo = new DynamicJsonObject();
+            djo.int1 = -19;
+            djo.decimal1 = 1.21M;
+            djo.string1 = "hi";
+
+            var dict = djo.ToDictionary();
+
+            Assert.IsNotNull(dict);
+            Assert.AreEqual(-19, dict["int1"]);
+            Assert.AreEqual(1.21M, dict["decimal1"]);
+            Assert.AreEqual("hi", dict["string1"]);
+
+            //Make sure the dictionary returned is readonly.
+            dict["int1"] = -20; //change the value we got before.
+            Assert.AreEqual(-19, djo.ToDictionary()["int1"]);  //reconvert and test again.
+        }
+    }
+}

--- a/Rally.RestApi.Test/Rally.RestApi.Test.csproj
+++ b/Rally.RestApi.Test/Rally.RestApi.Test.csproj
@@ -60,6 +60,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CachedRequestTest.cs" />
+    <Compile Include="DynamicJsonObjectTest.cs" />
     <Compile Include="Example.cs" />
     <Compile Include="OperationResultTest.cs" />
     <Compile Include="Properties\Settings.Designer.cs">

--- a/Rally.RestApi/Json/DynamicJsonObject.cs
+++ b/Rally.RestApi/Json/DynamicJsonObject.cs
@@ -17,6 +17,15 @@ namespace Rally.RestApi.Json
 		internal IDictionary<string, object> Dictionary { get; set; }
 
 		/// <summary>
+        /// Convert this object to a dictionary.
+        /// </summary>
+        /// <returns>this object as a dictionary</returns>
+        public IDictionary<string, object> ToDictionary()
+        {
+            return new Dictionary<string, object>(Dictionary);
+        }
+
+	    /// <summary>
 		/// Create a new object from the specified dictionary
 		/// </summary>
 		/// <param name="dictionary">A dictionary of members and values


### PR DESCRIPTION
Basically, returning a copy of the DynamicJsonObject.Dictionary property without exposing it or changing any functionality.