### PR TITLE
Enable calling Post using a Secured URI

### DIFF
--- a/Rally.RestApi/RallyRestApi.cs
+++ b/Rally.RestApi/RallyRestApi.cs
@@ -488,7 +488,7 @@ namespace Rally.RestApi
 				throw new InvalidOperationException("You must authenticate against Rally prior to performing any data operations.");
 
 			Uri uri = new Uri(String.Format("{0}slm/webservice/{1}/{2}", httpService.Server.AbsoluteUri, WsapiVersion, relativeUri));
-            return DoPost(uri, data, false);
+            return DoPost(uri, data, true);
 		}
 		#endregion
 

--- a/Rally.RestApi/RallyRestApi.cs
+++ b/Rally.RestApi/RallyRestApi.cs
@@ -488,8 +488,7 @@ namespace Rally.RestApi
 				throw new InvalidOperationException("You must authenticate against Rally prior to performing any data operations.");
 
 			Uri uri = new Uri(String.Format("{0}slm/webservice/{1}/{2}", httpService.Server.AbsoluteUri, WsapiVersion, relativeUri));
-			string postData = serializer.Serialize(data);
-			return serializer.Deserialize(httpService.Post(uri, postData, GetProcessedHeaders()));
+            return DoPost(uri, data, false);
 		}
 		#endregion
 


### PR DESCRIPTION
Needed the ability to call POST with the key attached to the end.

The Use case:
Imagine having a testset we wanted to add a test case to.  The way to do this:
![image](https://cloud.githubusercontent.com/assets/6966179/9666495/56d50998-5244-11e5-97c0-27fe1828c3e4.png)

```
Endpoint: = testset/TESTSET_NUMBER//testcases/add
// Defining the JSON PayLoad
DynamicJsonObject newTestCaseRef = new DynamicJsonObject();
DynamicJsonObject newTCField = new DynamicJsonObject();
newTCField["_ref"] = TestCaseRef;

RestAPI.Post(Endpoint, newTestCaseRef);
```

This does not work with current version of 3.0.1.  It comes back as unauthorized due to I believe the missing key.  The DoPost method is not public, so we cannot use it directly.  This seemed like the most logical change

//cc @ebsco/adapt