### PR TITLE
Configurable retries and trace

### DIFF
--- a/Rally.RestApi.UiForWinforms/RestApiAuthMgrWinforms.cs
+++ b/Rally.RestApi.UiForWinforms/RestApiAuthMgrWinforms.cs
@@ -29,9 +29,10 @@ namespace Rally.RestApi.UiForWinforms
 		/// for UI support.</param>
 		/// <param name="encryptionRoutines">The encryption routines to use for encryption/decryption of data. Only used for UI support.</param>
 		/// <param name="webServiceVersion">The version of the WSAPI API to use.</param>
+		/// <param name="traceInfo">Controls diagnostic trace information being logged</param>
 		public RestApiAuthMgrWinforms(string applicationToken, string encryptionKey,
-			IEncryptionRoutines encryptionRoutines, string webServiceVersion = RallyRestApi.DEFAULT_WSAPI_VERSION)
-			: base(true, applicationToken, encryptionKey, encryptionRoutines, webServiceVersion)
+			IEncryptionRoutines encryptionRoutines, string webServiceVersion = RallyRestApi.DEFAULT_WSAPI_VERSION, TraceFieldEnum traceInfo = RallyRestApi.DEFAULT_TRACE_FIELDS)
+			: base(true, applicationToken, encryptionKey, encryptionRoutines, webServiceVersion, traceInfo)
 		{
 		}
 		#endregion

--- a/Rally.RestApi/Auth/ApiAuthManager.cs
+++ b/Rally.RestApi/Auth/ApiAuthManager.cs
@@ -171,8 +171,9 @@ namespace Rally.RestApi.Auth
 		/// for UI support.</param>
 		/// <param name="encryptionRoutines">The encryption routines to use for encryption/decryption of data. Only used for UI support.</param>
 		/// <param name="webServiceVersion">The version of the WSAPI API to use.</param>
+		/// <param name="traceInfo">Controls diagnostic trace information being logged</param>
 		protected ApiAuthManager(bool isUiSupported, string applicationToken, string encryptionKey,
-			IEncryptionRoutines encryptionRoutines, string webServiceVersion = RallyRestApi.DEFAULT_WSAPI_VERSION)
+			IEncryptionRoutines encryptionRoutines, string webServiceVersion = RallyRestApi.DEFAULT_WSAPI_VERSION, TraceFieldEnum traceInfo = RallyRestApi.DEFAULT_TRACE_FIELDS)
 		{
 			if (isUiSupported)
 			{
@@ -203,7 +204,7 @@ namespace Rally.RestApi.Auth
 			}
 
 			IsUiSupported = isUiSupported;
-			Api = new RallyRestApi(this, webServiceVersion: webServiceVersion);
+			Api = new RallyRestApi(this, webServiceVersion: webServiceVersion, traceInfo: traceInfo);
 		}
 		#endregion
 

--- a/Rally.RestApi/Auth/ApiConsoleAuthManager.cs
+++ b/Rally.RestApi/Auth/ApiConsoleAuthManager.cs
@@ -15,8 +15,9 @@ namespace Rally.RestApi.Auth
 		/// Constructor
 		/// </summary>
 		/// <param name="webServiceVersion">The version of the WSAPI API to use.</param>
-		public ApiConsoleAuthManager(string webServiceVersion = RallyRestApi.DEFAULT_WSAPI_VERSION)
-			: base(false, null, null, null, webServiceVersion)
+		/// <param name="traceInfo">Controls diagnostic trace information being logged</param>
+		public ApiConsoleAuthManager(string webServiceVersion = RallyRestApi.DEFAULT_WSAPI_VERSION, TraceFieldEnum traceInfo = RallyRestApi.DEFAULT_TRACE_FIELDS)
+			: base(false, null, null, null, webServiceVersion, traceInfo)
 		{
 		}
 		#endregion

--- a/Rally.RestApi/Rally.RestApi.csproj
+++ b/Rally.RestApi/Rally.RestApi.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Connection\ConnectionType.cs" />
     <Compile Include="Exceptions\RallyFailedToDeserializeJson.cs" />
     <Compile Include="Response\AttachmentResult.cs" />
+    <Compile Include="TraceHelper.cs" />
     <Compile Include="Web\SsoWebClient.cs" />
     <Compile Include="Web\CookieAwareCacheableWebClient.cs" />
     <Compile Include="Web\CookieAwareWebClient.cs" />

--- a/Rally.RestApi/RallyRestApi.cs
+++ b/Rally.RestApi/RallyRestApi.cs
@@ -120,6 +120,10 @@ namespace Rally.RestApi
 		/// </summary>
 		public const string DEFAULT_WSAPI_VERSION = "v2.0";
 		/// <summary>
+		/// The default Trace fields
+		/// </summary>
+		public const TraceFieldEnum DEFAULT_TRACE_FIELDS = TraceFieldEnum.Data | TraceFieldEnum.Headers | TraceFieldEnum.Cookies;
+		/// <summary>
 		/// The default server to use: (https://rally1.rallydev.com)
 		/// </summary>
 		public const string DEFAULT_SERVER = "https://rally1.rallydev.com";
@@ -178,6 +182,7 @@ namespace Rally.RestApi
 		/// provided a console authentication manager will be used which does not allow SSO authentication.</param>
 		/// <param name="webServiceVersion">The WSAPI version to use (defaults to DEFAULT_WSAPI_VERSION)</param>
 		/// <param name="maxRetries">Requests will be attempted a number of times (defaults to 3)</param>
+		/// <param name="traceInfo">Controls diagnostic trace information being logged</param>
 		/// <example>
 		/// For a console application, no authentication manager is needed as shown in this example.
 		/// <code language="C#">
@@ -198,13 +203,15 @@ namespace Rally.RestApi
 		/// wpfAuthMgr = new RestApiAuthMgrWpf(applicationToken, encryptionKey, encryptionUtilities);
 		/// </code>
 		/// </example>
-		public RallyRestApi(ApiAuthManager authManger = null, string webServiceVersion = DEFAULT_WSAPI_VERSION, int maxRetries = 3)
+		public RallyRestApi(ApiAuthManager authManger = null, string webServiceVersion = DEFAULT_WSAPI_VERSION, int maxRetries = 3, TraceFieldEnum traceInfo = RallyRestApi.DEFAULT_TRACE_FIELDS)
 		{
 			// NOTE: The example for using the RestApiAuthMgrWpf is also shown there. Make sure you 
 			// update both if you change it.
 
+			TraceHelper.TraceFields = traceInfo;
+
 			if (authManger == null)
-				authManger = new ApiConsoleAuthManager();
+				authManger = new ApiConsoleAuthManager(webServiceVersion, traceInfo);
 
 			this.authManger = authManger;
 
@@ -597,7 +604,7 @@ namespace Rally.RestApi
 				alreadyDownloadedItems = request.Start - 1 + request.PageSize;
 			}
 
-			Trace.TraceInformation("The number of threaded requests is : {0}", subsequentQueries.Count);
+			TraceHelper.TraceMessage("The number of threaded requests is : {0}", subsequentQueries.Count);
 
 			var resultDictionary = new Dictionary<int, QueryResult>();
 			Parallel.ForEach(subsequentQueries, new ParallelOptions { MaxDegreeOfParallelism = MAX_THREADS_ALLOWED }, request1 =>

--- a/Rally.RestApi/RallyRestApi.cs
+++ b/Rally.RestApi/RallyRestApi.cs
@@ -132,6 +132,7 @@ namespace Rally.RestApi
 		#region Properties and Fields
 		private ApiAuthManager authManger;
 		private HttpService httpService;
+		private int maxRetries;
 		private readonly DynamicJsonSerializer serializer = new DynamicJsonSerializer();
 		/// <summary>
 		/// The HTTP headers to be included on all REST requests
@@ -176,6 +177,7 @@ namespace Rally.RestApi
 		/// <param name="authManger">The authorization manager to use when authentication requires it. If no driver is 
 		/// provided a console authentication manager will be used which does not allow SSO authentication.</param>
 		/// <param name="webServiceVersion">The WSAPI version to use (defaults to DEFAULT_WSAPI_VERSION)</param>
+		/// <param name="maxRetries">Requests will be attempted a number of times (defaults to 3)</param>
 		/// <example>
 		/// For a console application, no authentication manager is needed as shown in this example.
 		/// <code language="C#">
@@ -196,7 +198,7 @@ namespace Rally.RestApi
 		/// wpfAuthMgr = new RestApiAuthMgrWpf(applicationToken, encryptionKey, encryptionUtilities);
 		/// </code>
 		/// </example>
-		public RallyRestApi(ApiAuthManager authManger = null, string webServiceVersion = DEFAULT_WSAPI_VERSION)
+		public RallyRestApi(ApiAuthManager authManger = null, string webServiceVersion = DEFAULT_WSAPI_VERSION, int maxRetries = 3)
 		{
 			// NOTE: The example for using the RestApiAuthMgrWpf is also shown there. Make sure you 
 			// update both if you change it.
@@ -211,6 +213,8 @@ namespace Rally.RestApi
 				WsapiVersion = DEFAULT_WSAPI_VERSION;
 
 			AuthenticationState = AuthenticationResult.NotAuthorized;
+
+			this.maxRetries = maxRetries;
 		}
 		#endregion
 
@@ -1339,7 +1343,7 @@ namespace Rally.RestApi
 				Dictionary<string, string> processedHeaders = GetProcessedHeaders();
 				DynamicJsonObject response = serializer.Deserialize(httpService.GetAsPost(GetSecuredUri(uri), data, processedHeaders));
 
-				if (retry && response[response.Fields.First()].Errors.Count > 0 && retryCounter < 3)
+				if (retry && response[response.Fields.First()].Errors.Count > 0 && retryCounter < this.maxRetries)
 				{
 					ConnectionInfo.SecurityToken = GetSecurityToken();
 					httpService = new HttpService(authManger, ConnectionInfo);
@@ -1351,7 +1355,7 @@ namespace Rally.RestApi
 			}
 			catch (Exception)
 			{
-				if (retryCounter < 3)
+				if (retryCounter < this.maxRetries)
 				{
 					Thread.Sleep(retrySleepTime * retryCounter);
 					return DoGetAsPost(request, true, ++retryCounter);
@@ -1378,7 +1382,7 @@ namespace Rally.RestApi
 				Dictionary<string, string> processedHeaders = GetProcessedHeaders();
 				DynamicJsonObject response = serializer.Deserialize(httpService.Get(uri, processedHeaders));
 
-				if (retry && response[response.Fields.First()].Errors.Count > 0 && retryCounter < 3)
+				if (retry && response[response.Fields.First()].Errors.Count > 0 && retryCounter < this.maxRetries)
 				{
 					ConnectionInfo.SecurityToken = GetSecurityToken();
 					httpService = new HttpService(authManger, ConnectionInfo);
@@ -1390,7 +1394,7 @@ namespace Rally.RestApi
 			}
 			catch (Exception)
 			{
-				if (retryCounter < 3)
+				if (retryCounter < this.maxRetries)
 				{
 					Thread.Sleep(retrySleepTime * retryCounter);
 					return DoGet(uri, true, ++retryCounter);
@@ -1417,7 +1421,7 @@ namespace Rally.RestApi
 				Dictionary<string, string> processedHeaders = GetProcessedHeaders();
 				var response = serializer.Deserialize(httpService.Post(GetSecuredUri(uri), serializer.Serialize(data), processedHeaders));
 
-				if (retry && response[response.Fields.First()].Errors.Count > 0 && retryCounter < 3)
+				if (retry && response[response.Fields.First()].Errors.Count > 0 && retryCounter < this.maxRetries)
 				{
 					ConnectionInfo.SecurityToken = GetSecurityToken();
 					httpService = new HttpService(authManger, ConnectionInfo);
@@ -1429,7 +1433,7 @@ namespace Rally.RestApi
 			}
 			catch (Exception)
 			{
-				if (retryCounter < 3)
+				if (retryCounter < this.maxRetries)
 				{
 					Thread.Sleep(retrySleepTime * retryCounter);
 					return DoPost(uri, data, true, ++retryCounter);
@@ -1479,7 +1483,7 @@ namespace Rally.RestApi
 		{
 			try
 			{
-				DynamicJsonObject securityTokenResponse = DoGet(new Uri(GetFullyQualifiedRef(SECURITY_ENDPOINT)));
+				DynamicJsonObject securityTokenResponse = DoGet(new Uri(GetFullyQualifiedRef(SECURITY_ENDPOINT)), this.maxRetries > 1);
 				return securityTokenResponse["OperationResult"]["SecurityToken"];
 			}
 			catch

--- a/Rally.RestApi/TraceHelper.cs
+++ b/Rally.RestApi/TraceHelper.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Rally.RestApi
+{
+	/// <summary>
+	/// Diagnostic trace settings
+	/// </summary>
+	[Flags]
+	public enum TraceFieldEnum
+	{
+		/// <summary>
+		/// No trace
+		/// </summary>
+		None = 0,
+
+		/// <summary>
+		/// Includes Request/Response Data
+		/// </summary>
+		Data = 1,
+
+		/// <summary>
+		/// Include Request/Response Headers
+		/// </summary>
+		Headers = 2,
+
+		/// <summary>
+		/// Include Before/After Cookies
+		/// </summary>
+		Cookies = 4
+	}
+
+	/// <summary>
+	/// Helper class for logging diagnostic trace messages
+	/// </summary>
+	public static class TraceHelper
+	{
+		/// <summary>
+		/// Variable controlling level of Trace output
+		/// </summary>
+		public static TraceFieldEnum TraceFields { get; set; }
+
+		/// <summary>
+		/// Log a Trace message
+		/// </summary>
+		public static void TraceMessage(string format, params object[] args)
+		{
+			if (TraceHelper.TraceFields > 0)
+			{
+				Trace.TraceInformation(format + "\r\n\r\n", args);
+			}
+		}
+
+		/// <summary>
+		/// Log a Http Trace message
+		/// </summary>
+		public static void TraceHttpMessage(string action, DateTime startTime, Uri target, string requestHeaders, object responseData, string responseHeaders)
+		{
+			TraceHttpMessage(action, startTime, target, null, requestHeaders, null, responseData, responseHeaders, null);
+		}
+
+		/// <summary>
+		/// Log a Http Trace message
+		/// </summary>
+		public static void TraceHttpMessage(string action, DateTime startTime, Uri target, string requestHeaders, string cookiesBefore, object responseData, string responseHeaders, string cookiesAfter)
+		{
+			TraceHttpMessage(action, startTime, target, null, requestHeaders, cookiesBefore, responseData, responseHeaders, cookiesAfter);
+		}
+
+		/// <summary>
+		/// Log a Http Trace message
+		/// </summary>
+		public static void TraceHttpMessage(string action, DateTime startTime, Uri target, object requestData, string requestHeaders, string cookiesBefore, object responseData, string responseHeaders, string cookiesAfter)
+		{
+			if (TraceHelper.TraceFields > 0)
+			{
+				string traceRequestData = "", traceResponseData = "", traceRequestHeaders = "", traceResponseHeaders = "", traceCookiesBefore = "", traceCookiesAfter = "";
+
+				var traceSummary = string.Format("{0} ({1}):\r\n{2}", action, DateTime.Now.Subtract(startTime).ToString(), target.ToString());
+
+				// Include data
+				if (TraceHelper.TraceFields.HasFlag(TraceFieldEnum.Data))
+				{
+					traceRequestData = requestData == null ? "" : string.Format("\r\nRequest Data:\r\n{0}\r\n", requestData);
+					traceResponseData = string.Format("\r\nResponse Data\r\n{0}", responseData);
+				}
+
+				// Include headers
+				if (TraceHelper.TraceFields.HasFlag(TraceFieldEnum.Headers))
+				{
+					traceRequestHeaders = string.Format("\r\nRequest Headers:\r\n{0}", requestHeaders);
+					traceResponseHeaders = string.Format("\r\nResponse Headers:\r\n{0}", responseHeaders);
+				}
+
+				// Include cookies
+				if (TraceHelper.TraceFields.HasFlag(TraceFieldEnum.Cookies))
+				{
+					traceCookiesBefore = string.Format("\r\nCookies Before:\r\n{0}", cookiesBefore);
+					traceCookiesAfter = string.Format("\r\nCookies After:\r\n{0}", cookiesAfter);
+				}
+
+				// Log the trace information
+				Trace.TraceInformation(String.Concat(
+					traceSummary,
+					traceRequestHeaders,
+					traceCookiesBefore,
+					traceRequestData,
+					traceResponseHeaders,
+					traceCookiesAfter,
+					traceResponseData,
+					"\r\n\r\n"));
+			}
+		}
+	}
+}

--- a/Rally.RestApi/Web/HttpService.cs
+++ b/Rally.RestApi/Web/HttpService.cs
@@ -123,14 +123,7 @@ namespace Rally.RestApi.Web
 			}
 			finally
 			{
-				Trace.TraceInformation("Get ({0}):\r\n{1}\r\nRequest Headers:\r\n{2}Cookies Before:\r\n{3}Response Headers:\r\n{4}Cookies After:\r\n{5}Response Data\r\n{6}",
-															 DateTime.Now.Subtract(startTime).ToString(),
-															 target.ToString(),
-															 requestHeaders,
-															 cookiesBefore,
-															 responseHeaders,
-															 cookiesAfter,
-															 response);
+				TraceHelper.TraceHttpMessage("GET", startTime, target, requestHeaders, cookiesBefore, response, responseHeaders, cookiesAfter);
 			}
 		}
 		#endregion
@@ -159,15 +152,7 @@ namespace Rally.RestApi.Web
 			}
 			finally
 			{
-				Trace.TraceInformation("Post ({0}):\r\n{1}\r\nRequest Headers:\r\n{2}Cookies Before:\r\n{3}Request Data:\r\n{4}\r\nResponse Headers:\r\n{5}Cookies After:\r\n{6}Response Data\r\n{7}",
-															 DateTime.Now.Subtract(startTime).ToString(),
-															 target.ToString(),
-															 requestHeaders,
-															 cookiesBefore,
-															 data,
-															 responseHeaders,
-															 cookiesAfter,
-															 response);
+				TraceHelper.TraceHttpMessage("POST", startTime, target, data, requestHeaders, cookiesBefore, response, responseHeaders, cookiesAfter);
 			}
 		}
 		#endregion
@@ -211,15 +196,7 @@ namespace Rally.RestApi.Web
 			}
 			finally
 			{
-				Trace.TraceInformation("Post ({0}):\r\n{1}\r\nRequest Headers:\r\n{2}Cookies Before:\r\n{3}Request Data:\r\n{4}\r\nResponse Headers:\r\n{5}Cookies After:\r\n{6}Response Data\r\n{7}",
-															 DateTime.Now.Subtract(startTime).ToString(),
-															 target.ToString(),
-															 requestHeaders,
-															 cookiesBefore,
-															 data,
-															 responseHeaders,
-															 cookiesAfter,
-															 response);
+				TraceHelper.TraceHttpMessage("POST", startTime, target, data, requestHeaders, cookiesBefore, response, responseHeaders, cookiesAfter);
 			}
 		}
 		#endregion
@@ -257,14 +234,7 @@ namespace Rally.RestApi.Web
 			}
 			finally
 			{
-				Trace.TraceInformation("Get ({0}):\r\n{1}\r\nRequest Headers:\r\n{2}Cookies Before:\r\n{3}Response Headers:\r\n{4}Cookies After:\r\n{5}Response Data\r\n{6}",
-															 DateTime.Now.Subtract(startTime).ToString(),
-															 target.ToString(),
-															 requestHeaders,
-															 cookiesBefore,
-															 responseHeaders,
-															 cookiesAfter,
-															 response);
+				TraceHelper.TraceHttpMessage("GET", startTime, target, requestHeaders, cookiesBefore, response, responseHeaders, cookiesAfter);
 			}
 		}
 		#endregion
@@ -300,12 +270,7 @@ namespace Rally.RestApi.Web
 			}
 			finally
 			{
-				Trace.TraceInformation("Get ({0}):\r\n{1}\r\nRequest Headers:\r\n{2}Response Headers:\r\n{3}Response Data\r\n{4}",
-															 DateTime.Now.Subtract(startTime).ToString(),
-															 target.ToString(),
-															 requestHeaders,
-															 responseHeaders,
-															 response);
+				TraceHelper.TraceHttpMessage("GET", startTime, target, requestHeaders, response, responseHeaders);
 			}
 		}
 		#endregion
@@ -353,14 +318,7 @@ namespace Rally.RestApi.Web
 			}
 			finally
 			{
-				Trace.TraceInformation("Delete ({0}):\r\n{1}\r\nRequest Headers:\r\n{2}Cookies Before:\r\n{3}Response Headers:\r\n{4}Cookies After:\r\n{5}Response Data\r\n{6}",
-															 DateTime.Now.Subtract(startTime).ToString(),
-															 target.ToString(),
-															 requestHeaders,
-															 cookiesBefore,
-															 responseHeaders,
-															 cookiesAfter,
-															 response);
+				TraceHelper.TraceHttpMessage("DELETE", startTime, target, requestHeaders, cookiesBefore, response, responseHeaders, cookiesAfter);
 			}
 		}
 		#endregion


### PR DESCRIPTION
I see you already fixed the "infinite retry" bug and reduced the retries from 10 to 3, but i still find that excessive.  Particularly the retries on a succesful response when `.Errors` collection has items in it.  Eg if I request a User Story and that US doesnt exist, the error "item not found" is sent back, and this framework then retries to get that missing item multiple times (when it will never be there).

I also find the exponential back off logic a little annoying since 10 retries meant it would sleep for 55 seconds!  Even with 3 retries you are sleeping for 3+2+1 seconds.  
Not wanting to change the default behaviour, ive just added the ability to pass in the number of attempts desired, so in our case we can set things up to do no retries :+1:

I also found the diagnostic trace output very noisy so i tidied up that code and added a `TraceInfo` enum flags that can be used to specify the trace info to contain Body, Headers, Cookies (or nothing) as required